### PR TITLE
Fix Babel extend helper being inserted before goog.module

### DIFF
--- a/src/org/plovr/AbstractJavaScriptBasedCompiler.java
+++ b/src/org/plovr/AbstractJavaScriptBasedCompiler.java
@@ -22,8 +22,8 @@ import com.google.common.io.Resources;
  */
 abstract class AbstractJavaScriptBasedCompiler<T extends Exception> {
 
-  /** Scope that has the compiler in memory. */
-  private final Bindings globalScope;
+  /** ScriptEngine that has the compiler in memory. */
+  private final ScriptEngine engine;
 
   /**
    * @param pathToCompiler should be a path that can be loaded via
@@ -38,7 +38,7 @@ abstract class AbstractJavaScriptBasedCompiler<T extends Exception> {
         ScriptEngineManager factory = new ScriptEngineManager();
         ScriptEngine engine = factory.getEngineByName("JavaScript");
         engine.eval(compilerJs);
-        globalScope = engine.getBindings(ScriptContext.ENGINE_SCOPE);
+        this.engine = engine;
       } catch (ScriptException e) {
         throw new RuntimeException(e); // This should never happen
       }
@@ -56,10 +56,6 @@ abstract class AbstractJavaScriptBasedCompiler<T extends Exception> {
       String sourceName) throws T {
 
     try {
-      ScriptEngineManager factory = new ScriptEngineManager();
-      ScriptEngine engine = factory.getEngineByName("JavaScript");
-      engine.setBindings(globalScope, ScriptContext.GLOBAL_SCOPE);
-
       Bindings localBindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
       String js = insertScopeVariablesAndGenerateExecutableJavaScript(
           localBindings, sourceCode, sourceName);

--- a/src/org/plovr/JsxCompiler.java
+++ b/src/org/plovr/JsxCompiler.java
@@ -25,7 +25,7 @@ public class JsxCompiler
   @Override
   protected String insertScopeVariablesAndGenerateExecutableJavaScript(Bindings compileScope, String sourceCode, String sourceName) {
     compileScope.put("input", sourceCode);
-    return "Babel.transform(input, {presets: ['react']}).code";
+    return "Babel.transform(input, {presets: ['react'], plugins: [['transform-react-jsx', {useBuiltIns: true}]]}).code";
   }
 
   private static class JsxCompilerHolder {

--- a/test/org/plovr/JsxCompilerTest.java
+++ b/test/org/plovr/JsxCompilerTest.java
@@ -10,16 +10,29 @@ public class JsxCompilerTest {
 
   @Test
   public void testSimpleCompilation() throws IOException {
+    String compiledJsx = JsxCompiler.getInstance().compile(
+        "const element = <h1 className=\"greeting\">Hello, world!</h1>",
+        "testcase.jsx");
+    assertEquals(
+        "const element = React.createElement(\n" +
+            "  \"h1\",\n" +
+            "  { className: \"greeting\" },\n" +
+            "  \"Hello, world!\"\n" +
+            ");",
+        compiledJsx);
+  }
 
-  String compiledJsx = JsxCompiler.getInstance().compile(
-      "const element = <h1 className=\"greeting\">Hello, world!</h1>;",
-      "testcase.jsx");
-  assertEquals(
-      "const element = React.createElement(\n" +
-      "  \"h1\",\n" +
-      "  { className: \"greeting\" },\n" +
-      "  \"Hello, world!\"\n" +
-      ");",
-      compiledJsx);
+  @Test
+  public void testNoExtendsHelper() throws IOException {
+    String compiledJsx = JsxCompiler.getInstance().compile(
+        "<Test {...props} onClick={toast}>Hello, world!</Test>",
+        "testcase.jsx");
+    assertEquals(
+        "React.createElement(\n" +
+            "  Test,\n" +
+            "  Object.assign({}, props, { onClick: toast }),\n" +
+            "  \"Hello, world!\"\n" +
+            ");",
+        compiledJsx);
   }
 }


### PR DESCRIPTION
Babel will use Object.assign instead, which will be polyfilled
by Closure Compiler after the JSX transformation step

See
https://babeljs.io/docs/plugins/transform-react-jsx#usebuiltins