### PR TITLE
Changes to support the use of ES6 modules in Plovr.

### DIFF
--- a/src/org/plovr/AbstractJsInput.java
+++ b/src/org/plovr/AbstractJsInput.java
@@ -127,7 +127,7 @@ public abstract class AbstractJsInput implements JsInput {
 
     ErrorManager errorManager = new LoggerErrorManager(logger);
     JsFileParser parser = new JsFileParser(errorManager);
-    DependencyInfo dependencyInfo = parser.parseFile("<unknown path>", "<unknown path>", code);
+    DependencyInfo dependencyInfo = parser.parseFile(name, name, code);
 
     this.provides = ImmutableList.copyOf(dependencyInfo.getProvides());
     this.requires = ImmutableList.copyOf(dependencyInfo.getRequires());


### PR DESCRIPTION
This CR contains a relatively simple fix that (combined
with appropriate config.js files) allowed me to use ES6
modules with our version of Plovr. I was able to support
ES6 modules importing other ES6 modules or existing Goog
modules. I was not able to get existing Goog modules to
import ES6 modules as our version of the Closure compiler
does not contain the necessary backwards compatability
functionality.

J=SPR-524
TEST=manual

I tested the following scenarios outside Alpha:

1. An ES6 module A and another ES6 module B that imports A.
2. An ES6 module A that depends on an existing Goog module.
   Another ES6 module B that imports A.
3. A non-ES6 module A created using a goog.provide. Another
   non-ES6 module B that goog.requires A.
4. A non-ES6 module A created with a goog.module. Another
   non-ES6 module B, created with goog.module, that
   goog.requires A.

I added the generated plovr-lib.jar to Alpha and tested
these scenarios in one of Spurce's Storm applications:

1. Hot reloading of a JS change.
2. Hot reloading of a Soy change.
3. Converted a simple, existing React Component to an
   ES6 module and was able to import and use it successfully.
4. Tested hot reloading of changes to the modified React
   component.